### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Google Conversion Tracking SDK for iOS
 ========================
 
-This repo is purely used to cache versions of Google Conversion Tracking for use within Cocoapods. As long as Google does not add support of versioning.
+This repo is purely used to cache versions of Google Conversion Tracking for use within CocoaPods. As long as Google does not add support of versioning.
 
 Requirements:
 - An AdWords account.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
